### PR TITLE
use tail pid to kill

### DIFF
--- a/lib/controllers/fileTail.js
+++ b/lib/controllers/fileTail.js
@@ -29,7 +29,7 @@ function fileTail(file, stream, pid) {
 
 // kill tail process on exit
 function stop() {
-  process.kill(tail.pid);
+  tail.kill('SIGHUP');
 }
 
 // start broadcasting data


### PR DESCRIPTION
process.kill takes PID as argument. If it is not correct we will kill docker deamon.
using tail PID now and not tail object
